### PR TITLE
Change result element to optional in jobElement.rnc

### DIFF
--- a/webservice-utils/src/main/resources/org/daisy/pipeline/webservice-utils/resources/jobElement.rnc
+++ b/webservice-utils/src/main/resources/org/daisy/pipeline/webservice-utils/resources/jobElement.rnc
@@ -28,7 +28,7 @@ element job {
 		attribute href { xsd:anyURI }
 		& attribute mime-type { text }
 		& result+
-	}
+	}?
 }
 
 result= 


### PR DESCRIPTION
This is causing the framework complain every time a job is sent to a client.
