### PR TITLE
Treat "''" and """" as empty strings when checking the select value

### DIFF
--- a/framework-core/src/main/java/org/daisy/pipeline/job/URITranslatorHelper.java
+++ b/framework-core/src/main/java/org/daisy/pipeline/job/URITranslatorHelper.java
@@ -16,7 +16,8 @@ import com.google.common.base.Predicates;
 final class URITranslatorHelper   {
 
 	public static final boolean notEmpty(String value){
-		return value != null && !value.isEmpty();
+		return value != null && !value.isEmpty() && ! value.equals("''")
+			&& !value.equals("\"\"");
 	}
 
 	

--- a/framework-core/src/test/java/org/daisy/pipeline/job/URITranslatorHelperTest.java
+++ b/framework-core/src/test/java/org/daisy/pipeline/job/URITranslatorHelperTest.java
@@ -58,6 +58,8 @@ public class URITranslatorHelperTest   {
 	public void notEmpty(){
 		Assert.assertTrue(URITranslatorHelper.notEmpty("hola"));
 		Assert.assertFalse(URITranslatorHelper.notEmpty(""));
+		Assert.assertFalse(URITranslatorHelper.notEmpty("''"));
+		Assert.assertFalse(URITranslatorHelper.notEmpty("\"\""));
 		Assert.assertFalse(URITranslatorHelper.notEmpty(null));
 	}
 


### PR DESCRIPTION
In order to avoid output directories such as " file:/tmp/''/output" or "file:/tmp/""/output"
