### PR TITLE
Options order

### DIFF
--- a/framework-core/src/main/java/org/daisy/pipeline/script/XProcScript.java
+++ b/framework-core/src/main/java/org/daisy/pipeline/script/XProcScript.java
@@ -5,6 +5,7 @@ package org.daisy.pipeline.script;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +50,7 @@ public final class XProcScript {
 		private final Map<String, XProcPortMetadata> portsMetadata=new HashMap<String, XProcPortMetadata>();
 
 		/** The options metadata. */
-		private final Map<QName, XProcOptionMetadata> optionsMetadata=new HashMap<QName, XProcOptionMetadata>();
+		private final Map<QName, XProcOptionMetadata> optionsMetadata=new LinkedHashMap<QName, XProcOptionMetadata>();
 
 		/**
 		 * With pipeline info.

--- a/framework-core/src/test/java/org/daisy/pipeline/job/URITranslatorHelperTest.java
+++ b/framework-core/src/test/java/org/daisy/pipeline/job/URITranslatorHelperTest.java
@@ -136,8 +136,8 @@ public class URITranslatorHelperTest   {
 		List<XProcOptionInfo> infos=Lists.newLinkedList(mscript.getXProcPipelineInfo().getOptions());
 		Collection<XProcOptionInfo> filtered=Collections2.filter(infos,URITranslatorHelper.getTranslatableInputOptionsFilter(mscript));	
 		Assert.assertEquals(2,filtered.size());
-		Assert.assertEquals(Lists.newArrayList(filtered).get(0).getName(),optIn);
-		Assert.assertEquals(Lists.newArrayList(filtered).get(1).getName(),optOutNA);
+		Assert.assertEquals(Lists.newArrayList(filtered).get(0).getName(),optOutNA);
+		Assert.assertEquals(Lists.newArrayList(filtered).get(1).getName(),optIn);
 
 	}
 	

--- a/xproc-api/src/main/java/org/daisy/common/xproc/XProcPipelineInfo.java
+++ b/xproc-api/src/main/java/org/daisy/common/xproc/XProcPipelineInfo.java
@@ -32,7 +32,7 @@ public final class XProcPipelineInfo {
 		private final Map<String, XProcPortInfo> outputPorts = Maps.newHashMap();
 
 		/** The options. */
-		private final Map<QName, XProcOptionInfo> options = Maps.newHashMap();
+		private final Map<QName, XProcOptionInfo> options = Maps.newLinkedHashMap();
 
 		/**
 		 * Instantiates a new builder.
@@ -79,6 +79,7 @@ public final class XProcPipelineInfo {
 		 * @return the builder
 		 */
 		public Builder withOption(XProcOptionInfo option) {
+			System.out.println("Option in: "+option.getName());	
 			options.put(option.getName(), option);
 			return this;
 		}


### PR DESCRIPTION
Makes sure that the options are returned by the WebAPI in the same order as they appear in the script
