### PR TITLE
Close job's logging file when done

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -368,7 +368,6 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>
-        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/framework-core/pom.xml
+++ b/framework-core/pom.xml
@@ -21,6 +21,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.daisy.pipeline</groupId>
       <artifactId>common-utils</artifactId>
     </dependency>

--- a/framework-core/src/main/java/org/daisy/pipeline/job/impl/DefaultJobExecutionService.java
+++ b/framework-core/src/main/java/org/daisy/pipeline/job/impl/DefaultJobExecutionService.java
@@ -8,13 +8,15 @@ import org.daisy.common.priority.timetracking.TimeTrackerFactory;
 import org.daisy.common.xproc.XProcEngine;
 import org.daisy.pipeline.clients.Client;
 import org.daisy.pipeline.clients.Client.Role;
-import org.daisy.pipeline.job.JobQueue;
 import org.daisy.pipeline.job.Job;
 import org.daisy.pipeline.job.JobExecutionService;
+import org.daisy.pipeline.job.JobQueue;
 import org.daisy.pipeline.job.impl.fuzzy.FuzzyJobFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import ch.qos.logback.classic.ClassicConstants;
+
 
 import com.google.common.base.Predicate;
 
@@ -89,8 +91,8 @@ public class DefaultJobExecutionService implements JobExecutionService {
                                                         + job.getId().toString());
                                         MDC.put("jobid", job.getId().toString());
                                         job.run(xprocEngine);
+                                        logger.info(ClassicConstants.FINALIZE_SESSION_MARKER,"Stopping logging to job's log file");
                                         MDC.remove("jobid");
-                                        logger.info("Stopping logging to job's log file");
                                 } catch (Exception e) {
                                         throw new RuntimeException(e.getCause());
                                 }

--- a/logging-appender/src/main/java/org/daisy/pipeline/logging/IgnoreSiftAppender.java
+++ b/logging-appender/src/main/java/org/daisy/pipeline/logging/IgnoreSiftAppender.java
@@ -1,4 +1,5 @@
 package org.daisy.pipeline.logging;
+import ch.qos.logback.classic.ClassicConstants;
 import ch.qos.logback.classic.sift.SiftingAppender;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
@@ -12,10 +13,12 @@ public class IgnoreSiftAppender extends SiftingAppender {
 		String discriminatingValue = this.getDiscriminator().getDiscriminatingValue(event);
 		if( !"default".equals(discriminatingValue)){
 			super.append(event);
-		}else{
-			//ignore
-			return;
-		} 
+                        //Force closing the logging file when 
+                        //we finish the job
+                        if (event.getMarker()==ClassicConstants.FINALIZE_SESSION_MARKER){
+                                super.stop();
+                        }
+		}//else ignore
 		
 	}
 }


### PR DESCRIPTION
This solves a bug that prevented deleting the job's log in windows when removing the job
