### PR TITLE
Fix in calabash-adapter

### DIFF
--- a/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/EventBusMessageListener.java
+++ b/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/EventBusMessageListener.java
@@ -36,7 +36,7 @@ public class EventBusMessageListener implements XProcMessageListener {
 	}
 
 	private void post(MessageBuilder builder) {
-		if (props.getProperty("JOB_ID")!=null) {
+		if (props != null && props.getProperty("JOB_ID")!=null) {
 			builder.withJobId(props.getProperty("JOB_ID"));
 		}
 		builder.withSequence(sequence++);


### PR DESCRIPTION
EventBusMessageListener was causing trouble during XProcSpec testing

- tests would fail silently whenever a px:message was encountered
- XProc errors were never caught, instead the tests fail silently

@rdeltour I noticed you already prepared the release of pipeline-framework, but then I realized I didn't commit this fix yet. If it's not possible to include it in 1.9, that's not a tragedy. 