### PR TITLE
Mechanism for sending messages to execution log from Java

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -22,24 +22,24 @@
     <!-- Modules Versions -->
     <daisy.calabash-adapter.version>2.0.4-SNAPSHOT</daisy.calabash-adapter.version>
     <daisy.calabash-custom-steps.version>2.0.0</daisy.calabash-custom-steps.version>
-    <daisy.common-utils.version>2.1.3-SNAPSHOT</daisy.common-utils.version>
-    <daisy.framework-core.version>3.0.1-SNAPSHOT</daisy.framework-core.version>
+    <daisy.common-utils.version>3.0.0-SNAPSHOT</daisy.common-utils.version>
+    <daisy.framework-core.version>3.1.0-SNAPSHOT</daisy.framework-core.version>
     <daisy.framework-persistence.version>2.0.4-SNAPSHOT</daisy.framework-persistence.version>
     <daisy.framework-volatile.version>2.0.2-SNAPSHOT</daisy.framework-volatile.version>
     <daisy.launcher.version>1.0.0</daisy.launcher.version>
     <daisy.logging-activator.version>2.0.2-SNAPSHOT</daisy.logging-activator.version>
     <daisy.logging-appender.version>1.1.1-SNAPSHOT</daisy.logging-appender.version>
     <daisy.modules-registry.version>2.0.0</daisy.modules-registry.version>
-    <daisy.persistence-derby.version>2.0.0</daisy.persistence-derby.version>
+    <daisy.persistence-derby.version>2.0.1-SNAPSHOT</daisy.persistence-derby.version>
     <daisy.persistence-mysql.version>2.0.0</daisy.persistence-mysql.version>
-    <daisy.push-notifier.version>2.0.0</daisy.push-notifier.version>
+    <daisy.push-notifier.version>2.0.1-SNAPSHOT</daisy.push-notifier.version>
     <daisy.updater.version>1.0.1-SNAPSHOT</daisy.updater.version>
     <daisy.webservice.version>2.1.1-SNAPSHOT</daisy.webservice.version>
     <daisy.webservice-utils.version>2.2.1-SNAPSHOT</daisy.webservice-utils.version>
     <daisy.woodstox-osgi-adapter.version>2.0.0</daisy.woodstox-osgi-adapter.version>
     <daisy.xmlcatalog.version>2.0.2-SNAPSHOT</daisy.xmlcatalog.version>
     <daisy.xpath-registry.version>1.0.1</daisy.xpath-registry.version>
-    <daisy.xproc-api.version>2.0.0</daisy.xproc-api.version>
+    <daisy.xproc-api.version>2.0.1-SNAPSHOT</daisy.xproc-api.version>
 
     <!-- Dependencies Versions -->
     <benchmark.version>0.7.2</benchmark.version>

--- a/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/EventBusMessageListener.java
+++ b/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/EventBusMessageListener.java
@@ -26,7 +26,6 @@ public class EventBusMessageListener implements XProcMessageListener {
 	EventBusProvider eventBus;
 	MessageBuliderFactory messageBuilderFactory;
 	Properties props;
-	int sequence = 0;
 
 	public EventBusMessageListener(EventBusProvider eventBus,
 			 Properties props) {
@@ -40,7 +39,6 @@ public class EventBusMessageListener implements XProcMessageListener {
 		if (props != null && props.getProperty("JOB_ID")!=null) {
 			builder.withJobId(props.getProperty("JOB_ID"));
 		}
-		builder.withSequence(sequence++);
 		builder.withTimeStamp(new Date());
 		eventBus.get().post(builder.build());
 	}

--- a/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/XProcMessageListenerAggregator.java
+++ b/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/XProcMessageListenerAggregator.java
@@ -121,7 +121,7 @@ public class XProcMessageListenerAggregator implements XProcMessageListener{
 	@Override
 	public void warning(Throwable throwable) {
 		for(XProcMessageListener l:mListeners){
-			l.error(throwable);
+			l.warning(throwable);
 		}
 
 	}

--- a/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/slf4jXProcMessageListener.java
+++ b/calabash-adapter/src/main/java/org/daisy/common/xproc/calabash/impl/slf4jXProcMessageListener.java
@@ -26,21 +26,17 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
     /** The default logger. */
     private static Logger defaultLogger = LoggerFactory.getLogger("com.xmlcalabash");
 
-    /** The log. */
-    private Logger log = defaultLogger;
-
     /* (non-Javadoc)
      * @see com.xmlcalabash.core.XProcMessageListener#error(com.xmlcalabash.core.XProcRunnable, net.sf.saxon.s9api.XdmNode, java.lang.String, net.sf.saxon.s9api.QName)
      */
     @Override
 	public void error(XProcRunnable step, XdmNode node, String message, QName code) {
-
+        Logger log;
         if (step != null) {
             log = LoggerFactory.getLogger(step.getClass());
         } else {
             log = defaultLogger;
         }
-
         log.error(XprocMessageHelper.logLine(step, node, message, code));
     }
 
@@ -49,8 +45,7 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
      */
     @Override
 	public void error(Throwable exception) {
-
-
+        Logger log = defaultLogger;
         log.error(XprocMessageHelper.errorLogline(exception));
     }
 
@@ -59,6 +54,7 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
      */
     @Override
 	public void warning(XProcRunnable step, XdmNode node, String message) {
+        Logger log;
         if (step != null) {
             log = LoggerFactory.getLogger(step.getClass());
         } else {
@@ -72,6 +68,7 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
      */
     @Override
 	public void info(XProcRunnable step, XdmNode node, String message) {
+        Logger log;
         if (step != null) {
             log = LoggerFactory.getLogger(step.getClass());
         } else {
@@ -85,6 +82,7 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
      */
     @Override
 	public void fine(XProcRunnable step, XdmNode node, String message) {
+        Logger log;
         if (step != null) {
             log = LoggerFactory.getLogger(step.getClass());
         } else {
@@ -98,6 +96,7 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
      */
     @Override
 	public void finer(XProcRunnable step, XdmNode node, String message) {
+        Logger log;
         if (step != null) {
             log = LoggerFactory.getLogger(step.getClass());
         } else {
@@ -111,6 +110,7 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
      */
     @Override
 	public void finest(XProcRunnable step, XdmNode node, String message) {
+        Logger log;
         if (step != null) {
             log = LoggerFactory.getLogger(step.getClass());
         } else {
@@ -124,8 +124,8 @@ public class slf4jXProcMessageListener implements XProcMessageListener {
 	 */
 	@Override
 	public void warning(Throwable exception) {
-		 log.warn(XprocMessageHelper.errorLogline(exception));
-
+		Logger log = defaultLogger;
+		log.warn(XprocMessageHelper.errorLogline(exception));
 	}
 
 

--- a/common-utils/pom.xml
+++ b/common-utils/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>common-utils</artifactId>
-  <version>2.1.3-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
 
   <packaging>bundle</packaging>
   <name>DAISY Pipeline 2 :: Common Utilities</name>

--- a/common-utils/src/main/java/org/daisy/common/messaging/Message.java
+++ b/common-utils/src/main/java/org/daisy/common/messaging/Message.java
@@ -1,6 +1,8 @@
 package org.daisy.common.messaging;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Message {
 	/**
@@ -86,7 +88,6 @@ public class Message {
 		int line;
 		int column;
 		Date timeStamp;
-		int sequence;
 		String jobId;
 		String file;
 
@@ -127,12 +128,6 @@ public class Message {
 		}
 
 
-		public MessageBuilder withSequence(int sequence) {
-			this.sequence = sequence;
-			return this;
-		}
-
-
 		public MessageBuilder withJobId(String jobId) {
 			this.jobId = jobId;
 			return this;
@@ -145,11 +140,22 @@ public class Message {
 		}
 
 		public Message build() {
+			Integer sequence; {
+				if (jobId == null)
+					sequence = 0;
+				else {
+					sequence = messageCounts.get(jobId);
+					if (sequence == null)
+						sequence = 0;
+					messageCounts.put(jobId, sequence + 1);
+				}
+			}
 			return new Message(throwable, text, level, line, column,
 					timeStamp, sequence, jobId, file);
 		}
 
 	}
 
+	private final static Map<String,Integer> messageCounts = new HashMap<String,Integer>();
 
 }

--- a/framework-core/pom.xml
+++ b/framework-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>framework-core</artifactId>

--- a/framework-core/pom.xml
+++ b/framework-core/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.10.1-SNAPSHOT</version>
+    <version>1.10.0</version>
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>framework-core</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
   <name>DAISY Pipeline 2 :: Framework Core</name>
   <dependencies>

--- a/framework-core/src/main/java/org/daisy/pipeline/job/Job.java
+++ b/framework-core/src/main/java/org/daisy/pipeline/job/Job.java
@@ -193,7 +193,6 @@ public class Job implements RuntimeConfigurator.EventBusable{
                         .withJobId(this.getId().toString())
                         .withLevel(Level.ERROR)
                         .withText(text)
-                        .withSequence(1)
                         .build();
                 if (this.eventBus!=null)
                         this.eventBus.post(msg);

--- a/framework-volatile/src/test/java/org/daisy/pipeline/nonpersistent/impl/messaging/VolatileMessageAccessorTest.java
+++ b/framework-volatile/src/test/java/org/daisy/pipeline/nonpersistent/impl/messaging/VolatileMessageAccessorTest.java
@@ -32,14 +32,14 @@ public class VolatileMessageAccessorTest   {
 	public void setUp() {
 		String id = JobIdFactory.newId().toString();
 		m1 = new Message.MessageBuilder().withText("message1")
-				.withLevel(Level.INFO).withSequence(0).withJobId(id).build();
+				.withLevel(Level.INFO).withJobId(id).build();
 
 		m2 = new Message.MessageBuilder().withText("message2")
-				.withLevel(Level.ERROR).withSequence(1).withJobId(id)
+				.withLevel(Level.ERROR).withJobId(id)
 				.build();
 
 		m3 = new Message.MessageBuilder().withText("message3")
-				.withLevel(Level.WARNING).withSequence(2).withJobId(id)
+				.withLevel(Level.WARNING).withJobId(id)
 				.build();
 
 

--- a/framework-volatile/src/test/java/org/daisy/pipeline/nonpersistent/impl/messaging/VolatileMessageStorageTest.java
+++ b/framework-volatile/src/test/java/org/daisy/pipeline/nonpersistent/impl/messaging/VolatileMessageStorageTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.daisy.common.messaging.Message;
 import org.daisy.common.messaging.Message.Level;
+import org.daisy.pipeline.job.JobIdFactory;
 import org.daisy.pipeline.nonpersistent.impl.messaging.VolatileMessageStorage;
 import org.junit.After;
 import org.junit.Assert;
@@ -11,6 +12,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class VolatileMessageStorageTest {
+
+	String jobId;
 
 	Message m1;
 
@@ -22,15 +25,16 @@ public class VolatileMessageStorageTest {
 
 	@Before
 	public void setUp() {
+		jobId = JobIdFactory.newId().toString();
 		m1 = new Message.MessageBuilder().withText("message1")
-				.withLevel(Level.INFO).withSequence(0).withJobId("id1").build();
+				.withLevel(Level.INFO).withJobId(jobId).build();
 
 		m2 = new Message.MessageBuilder().withText("message2")
-				.withLevel(Level.ERROR).withSequence(1).withJobId("id1")
+				.withLevel(Level.ERROR).withJobId(jobId)
 				.build();
 
 		m3 = new Message.MessageBuilder().withText("message3")
-				.withLevel(Level.DEBUG).withSequence(2).withJobId("id1")
+				.withLevel(Level.DEBUG).withJobId(jobId)
 				.build();
 
 	}
@@ -43,7 +47,7 @@ public class VolatileMessageStorageTest {
 	public void add() {
 		storage.add(m1);
 		storage.add(m2);
-		Assert.assertEquals(storage.get("id1").size(), 2);
+		Assert.assertEquals(storage.get(jobId).size(), 2);
 	}
 
 	@Test
@@ -61,19 +65,19 @@ public class VolatileMessageStorageTest {
 		};
 		sleeper.start();
 		sleeper.join();
-		Assert.assertEquals(storage.get("id1").size(), 0);
+		Assert.assertEquals(storage.get(jobId).size(), 0);
 
 	}
 	@Test
 	public void addDebug() {
 		storage.add(m3);
-		Assert.assertEquals(0,storage.get("id1").size());
+		Assert.assertEquals(0,storage.get(jobId).size());
 	}
 	@Test
 	public void get() {
 		storage.add(m1);
 		storage.add(m2);
-		List<Message> list= storage.get("id1");
+		List<Message> list= storage.get(jobId);
 		Assert.assertEquals(0,list.get(0).getSequence());
 		Assert.assertEquals(1,list.get(1).getSequence());
 	}
@@ -88,8 +92,8 @@ public class VolatileMessageStorageTest {
 	public void remove() {
 		storage.add(m1);
 		storage.add(m2);
-		storage.remove("id1");
-		Assert.assertEquals(0,storage.get("id1").size());
+		storage.remove(jobId);
+		Assert.assertEquals(0,storage.get(jobId).size());
 	}
 
 }

--- a/logging-appender/pom.xml
+++ b/logging-appender/pom.xml
@@ -18,6 +18,19 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.daisy.pipeline</groupId>
+      <artifactId>common-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.pipeline</groupId>
+      <artifactId>framework-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>compile</scope>

--- a/logging-appender/src/main/java/org/daisy/pipeline/logging/EventBusAppender.java
+++ b/logging-appender/src/main/java/org/daisy/pipeline/logging/EventBusAppender.java
@@ -1,0 +1,99 @@
+package org.daisy.pipeline.logging;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.sift.MDCBasedDiscriminator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+import org.daisy.common.messaging.Message;
+import org.daisy.common.messaging.MessageBuliderFactory;
+import org.daisy.pipeline.event.EventBusProvider;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+
+/**
+ * Configure like this:
+ *
+ * &lt;appender name="EVENTBUS" class="org.daisy.pipeline.logging.EventBusAppender"&gt;
+ *   &lt;filter class="org.daisy.pipeline.logging.ThresholdFilter"&gt;
+ *     &lt;rootLevel&gt;INFO&lt;/rootLevel&gt;
+ *     &lt;loggerLevels&gt;
+ *       cz.vutbr.web=WARN
+ *       org.daisy.common.xproc.calabash.steps.Message=WARN
+ *       com.xmlcalabash.runtime.XAtomicStep=WARN
+ *     &lt;/loggerLevels&gt;
+ *   &lt;/filter&gt;
+ * &lt;/appender&gt;
+ */
+public class EventBusAppender extends AppenderBase<ILoggingEvent> {
+	
+	private EventBusProvider eventBusProvider;
+	private BundleContext bundleContext;
+	private MessageBuliderFactory messageBuilderFactory;
+	private List<ILoggingEvent> eventBuffer;
+	private MDCBasedDiscriminator discriminator;
+	
+	@Override
+	public void start() {
+		bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
+		messageBuilderFactory = new MessageBuliderFactory();
+		eventBuffer = new ArrayList<ILoggingEvent>();
+		discriminator = new MDCBasedDiscriminator();
+		discriminator.setKey("jobid");
+		discriminator.setDefaultValue("default");
+		super.start();
+	}
+	
+	protected void append(ILoggingEvent event) {
+		if (!isStarted())
+			return;
+		String jobId = discriminator.getDiscriminatingValue(event);
+		if (!"default".equals(jobId)) {
+			if (eventBusProvider == null) {
+				try {
+					eventBusProvider = bundleContext.getService(
+						bundleContext.getServiceReferences(EventBusProvider.class, null).iterator().next());
+					for (ILoggingEvent e : eventBuffer)
+						append(eventBusProvider, discriminator.getDiscriminatingValue(e), e);
+					eventBuffer.clear(); }
+				catch (Exception e) {
+					eventBuffer.add(event);
+					return; }}
+			append(eventBusProvider, jobId, event); }
+	}
+	
+	private void append(EventBusProvider eventBus, String jobId, ILoggingEvent event) {
+		Level level = event.getLevel();
+		Message m = messageBuilderFactory.newMessageBuilder()
+			.withTimeStamp(new Date())
+			.withJobId(jobId)
+			.withLevel(messageLevelFromLogbackLevel(level))
+			.withText(event.getFormattedMessage())
+			.build();
+		eventBus.get().post(m);
+	}
+	
+	private static Message.Level messageLevelFromLogbackLevel(Level level) {
+		switch(level.toInt()) {
+		case Level.TRACE_INT:
+			return Message.Level.TRACE;
+		case Level.DEBUG_INT:
+			return Message.Level.DEBUG;
+		case Level.INFO_INT:
+			return Message.Level.INFO;
+		case Level.WARN_INT:
+			return Message.Level.WARNING;
+		case Level.ERROR_INT:
+			return Message.Level.ERROR;
+		case Level.ALL_INT:
+		case Level.OFF_INT:
+		default:
+			return null; }
+	}
+}

--- a/logging-appender/src/main/java/org/daisy/pipeline/logging/ThresholdFilter.java
+++ b/logging-appender/src/main/java/org/daisy/pipeline/logging/ThresholdFilter.java
@@ -35,8 +35,6 @@ public class ThresholdFilter extends Filter<ILoggingEvent> {
 	
 	@Override
 	public void start() {
-		if (loggerLevels == null)
-			return;
 		if (rootLevel == null)
 			rootLevel = Level.ALL;
 		cache = new TreeMap<String,Level>();
@@ -51,10 +49,11 @@ public class ThresholdFilter extends Filter<ILoggingEvent> {
 		Level threshold = cache.get(logger);
 		if (threshold == null) {
 			threshold = rootLevel; {
-				for (String l : loggerLevels.keySet())
-					if (logger.startsWith(l)) {
-						threshold = loggerLevels.get(l);
-						break; }}
+				if (loggerLevels != null)
+					for (String l : loggerLevels.keySet())
+						if (logger.startsWith(l)) {
+							threshold = loggerLevels.get(l);
+							break; }}
 			cache.put(logger, threshold); }
 		Level level = event.getLevel();
 		if (level.isGreaterOrEqual(threshold))

--- a/logging-appender/src/main/java/org/daisy/pipeline/logging/ThresholdFilter.java
+++ b/logging-appender/src/main/java/org/daisy/pipeline/logging/ThresholdFilter.java
@@ -1,0 +1,65 @@
+package org.daisy.pipeline.logging;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeMap;
+
+import ch.qos.logback.classic.Level;
+import static ch.qos.logback.classic.Level.toLevel;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class ThresholdFilter extends Filter<ILoggingEvent> {
+	
+	private Level rootLevel;
+	private Map<String,Level> loggerLevels;
+	private Map<String,Level> cache;
+	
+	public void setRootLevel(Level rootLevel) {
+		this.rootLevel = rootLevel;
+	}
+	
+	public void setLoggerLevels(String loggerLevels) {
+		this.loggerLevels = new TreeMap<String,Level>();
+		try {
+			Properties p = new Properties();
+			p.load(new StringReader(loggerLevels));
+			for (String logger : p.stringPropertyNames())
+				this.loggerLevels.put(logger, toLevel(p.getProperty(logger))); }
+		catch (IOException e) {
+			throw new RuntimeException(e); }
+	}
+	
+	@Override
+	public void start() {
+		if (loggerLevels == null)
+			return;
+		if (rootLevel == null)
+			rootLevel = Level.ALL;
+		cache = new TreeMap<String,Level>();
+		super.start();
+	}
+
+	@Override
+	public FilterReply decide(ILoggingEvent event) {
+		if (!isStarted())
+			return FilterReply.NEUTRAL;
+		String logger = event.getLoggerName();
+		Level threshold = cache.get(logger);
+		if (threshold == null) {
+			threshold = rootLevel; {
+				for (String l : loggerLevels.keySet())
+					if (logger.startsWith(l)) {
+						threshold = loggerLevels.get(l);
+						break; }}
+			cache.put(logger, threshold); }
+		Level level = event.getLevel();
+		if (level.isGreaterOrEqual(threshold))
+			return FilterReply.NEUTRAL;
+		else
+			return FilterReply.DENY;
+	}
+}

--- a/persistence-derby/pom.xml
+++ b/persistence-derby/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.10.1-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,15 @@
     <module>logging-activator</module>
     <module>logging-appender</module>
     <!-- <module>modules-registry</module> -->
-    <!-- <module>persistence-derby</module> -->
+    <module>persistence-derby</module>
     <!-- <module>persistence-mysql</module> -->
-    <!-- <module>push-notifier</module> -->
+    <module>push-notifier</module>
     <module>updater</module>
     <module>webservice</module>
     <module>webservice-utils</module>
     <!-- <module>woodstox-osgi-adapter</module> -->
     <!-- <module>xpath-registry</module> -->
-    <!-- <module>xproc-api</module> -->
+    <module>xproc-api</module>
     <!-- <module>launcher</module> -->
   </modules>
   

--- a/push-notifier/pom.xml
+++ b/push-notifier/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.10.1-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 

--- a/webservice-utils/src/main/java/org/daisy/pipeline/webserviceutils/xml/JobXmlWriter.java
+++ b/webservice-utils/src/main/java/org/daisy/pipeline/webserviceutils/xml/JobXmlWriter.java
@@ -159,6 +159,7 @@ public class JobXmlWriter {
                         Element messageElm = doc.createElementNS(XmlUtils.NS_PIPELINE_DATA, "message");
                         messageElm.setAttribute("level", message.getLevel().toString());
                         messageElm.setAttribute("sequence", Integer.toString(message.getSequence()));
+                        messageElm.setAttribute("timeStamp", Long.toString(message.getTimeStamp().getTime()));
                         messageElm.setTextContent(message.getText());
                         messagesElm.appendChild(messageElm);
                     }

--- a/webservice-utils/src/main/resources/org/daisy/pipeline/webservice-utils/resources/jobElement.rnc
+++ b/webservice-utils/src/main/resources/org/daisy/pipeline/webservice-utils/resources/jobElement.rnc
@@ -22,6 +22,7 @@ element job {
 			element message { 
 				attribute level { message.level }
 				& attribute sequence { text }
+				& attribute timeStamp { xsd:long }
 				& text
 			}*
 		}?

--- a/xproc-api/pom.xml
+++ b/xproc-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy.pipeline</groupId>
     <artifactId>framework-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.10.1-SNAPSHOT</version>
     <relativePath>../parent</relativePath>
   </parent>
 


### PR DESCRIPTION
... using a custom Logback appender that sents log messages to the
EventBus. Attaching the right job ID is done using the same MDC based
principle that was already used in IgnoreSiftAppender.

This fixes issue daisy/pipeline-issues#477

Note that this also follows the proposal of unifying the two types of
messages (execution log and detailed log) through one and the same
mechanism, except that XProc/XSLT messages are still sent directly to
the EventBus: see issue
daisy/pipeline-issues#478.

In order to support messages belonging to one job coming from several
sources, the message sequence numbers are now computed automatically
within MessageBuilder, and the withSequence method has been removed.
